### PR TITLE
Fix for issue #260.

### DIFF
--- a/biolinkml/meta.py
+++ b/biolinkml/meta.py
@@ -1,5 +1,5 @@
 # Auto generated from meta.yaml by pythongen.py version: 0.4.0
-# Generation date: 2020-08-25 16:38
+# Generation date: 2020-08-26 16:26
 # Schema: metamodel
 #
 # id: https://w3id.org/biolink/biolinkml/meta
@@ -861,6 +861,3 @@ slots.class_definition_mixins = Slot(uri=META.mixins, name="class_definition_mix
 
 slots.class_definition_apply_to = Slot(uri=META.apply_to, name="class_definition_apply_to", curie=META.curie('apply_to'),
                       model_uri=META.class_definition_apply_to, domain=ClassDefinition, range=List[Union[str, ClassDefinitionName]])
-
-slots.annotation_extension_value = Slot(uri=META.value, name="annotation_extension_value", curie=META.curie('value'),
-                      model_uri=META.annotation_extension_value, domain=Annotation, range=Bool)

--- a/includes/annotations.py
+++ b/includes/annotations.py
@@ -1,5 +1,5 @@
 # Auto generated from annotations.yaml by pythongen.py version: 0.4.0
-# Generation date: 2020-08-25 16:38
+# Generation date: 2020-08-26 16:26
 # Schema: annotations
 #
 # id: https://w3id.org/biolink/biolinkml/annotations
@@ -22,7 +22,7 @@ from rdflib import Namespace, URIRef
 from biolinkml.utils.curienamespace import CurieNamespace
 from biolinkml.utils.metamodelcore import Bool, URIorCURIE
 from includes.extensions import Extension
-from includes.types import Boolean, Uriorcurie
+from includes.types import Boolean, String, Uriorcurie
 
 metamodel_version = "1.5.3"
 

--- a/includes/extensions.py
+++ b/includes/extensions.py
@@ -1,5 +1,5 @@
 # Auto generated from extensions.yaml by pythongen.py version: 0.4.0
-# Generation date: 2020-08-25 16:38
+# Generation date: 2020-08-25 15:31
 # Schema: extensions
 #
 # id: https://w3id.org/biolink/biolinkml/extensions

--- a/includes/mappings.py
+++ b/includes/mappings.py
@@ -1,5 +1,5 @@
 # Auto generated from mappings.yaml by pythongen.py version: 0.4.0
-# Generation date: 2020-08-25 16:38
+# Generation date: 2020-08-25 15:31
 # Schema: mappings
 #
 # id: https://w3id.org/biolink/biolinkml/mappings

--- a/includes/types.py
+++ b/includes/types.py
@@ -1,5 +1,5 @@
 # Auto generated from types.yaml by pythongen.py version: 0.4.0
-# Generation date: 2020-08-25 16:38
+# Generation date: 2020-08-25 15:31
 # Schema: types
 #
 # id: https://w3id.org/biolink/biolinkml/types

--- a/meta.jsonld
+++ b/meta.jsonld
@@ -3,7 +3,7 @@
   "description": "A metamodel for defining biolink related schemas",
   "id": "https://w3id.org/biolink/biolinkml/meta",
   "title": "Biolink Schema Metamodel",
-  "version": "1.5.4",
+  "version": "1.5.8",
   "imports": [
     "biolinkml:types",
     "biolinkml:mappings",
@@ -2091,6 +2091,7 @@
     {
       "name": "annotation_extension_value",
       "from_schema": "https://w3id.org/biolink/biolinkml/meta",
+      "imported_from": "biolinkml:annotations",
       "is_a": "extension_value",
       "domain": "Annotation",
       "range": "boolean",
@@ -2590,9 +2591,9 @@
   ],
   "metamodel_version": "1.5.3",
   "source_file": "meta.yaml",
-  "source_file_date": "Tue Aug 25 16:38:08 2020",
+  "source_file_date": "Tue Aug 25 12:56:39 2020",
   "source_file_size": 27254,
-  "generation_date": "2020-08-25 16:38",
+  "generation_date": "2020-08-26 16:26",
   "type": "SchemaDefinition",
   "@context": [
     "https://w3id.org/biolink/biolinkml/context.jsonld",

--- a/meta.ttl
+++ b/meta.ttl
@@ -17,7 +17,7 @@
 meta:metamodel a meta:SchemaDefinition ;
     dcterms:license "https://creativecommons.org/publicdomain/zero/1.0/" ;
     dcterms:title "Biolink Schema Metamodel" ;
-    pav:version "1.5.4" ;
+    pav:version "1.5.8" ;
     skos:definition "A metamodel for defining biolink related schemas" ;
     meta:classes meta:AltDescription,
         meta:Annotatable,
@@ -46,29 +46,29 @@ meta:metamodel a meta:SchemaDefinition ;
         "rdfs",
         "skos",
         "xsd" ;
-    meta:generation_date "2020-08-25 16:38"^^xsd:dateTime ;
+    meta:generation_date "2020-08-26 16:26"^^xsd:dateTime ;
     meta:id biolinkml:meta ;
     meta:imports biolinkml:annotations,
         biolinkml:extensions,
         biolinkml:mappings,
         biolinkml:types ;
     meta:metamodel_version "1.5.3" ;
-    meta:prefixes [ meta:prefix_prefix "skos" ;
-            meta:prefix_reference skos: ],
-        [ meta:prefix_prefix "biolinkml" ;
+    meta:prefixes [ meta:prefix_prefix "biolinkml" ;
             meta:prefix_reference biolinkml: ],
         [ meta:prefix_prefix "oslc" ;
             meta:prefix_reference oslc: ],
-        [ meta:prefix_prefix "schema" ;
-            meta:prefix_reference schema: ],
+        [ meta:prefix_prefix "OIO" ;
+            meta:prefix_reference OIO: ],
         [ meta:prefix_prefix "meta" ;
             meta:prefix_reference meta: ],
-        [ meta:prefix_prefix "bibo" ;
-            meta:prefix_reference bibo: ],
+        [ meta:prefix_prefix "schema" ;
+            meta:prefix_reference schema: ],
         [ meta:prefix_prefix "pav" ;
             meta:prefix_reference pav: ],
-        [ meta:prefix_prefix "OIO" ;
-            meta:prefix_reference OIO: ] ;
+        [ meta:prefix_prefix "bibo" ;
+            meta:prefix_reference bibo: ],
+        [ meta:prefix_prefix "skos" ;
+            meta:prefix_reference skos: ] ;
     meta:slots meta:abstract,
         meta:alias,
         meta:aliases,
@@ -181,7 +181,7 @@ meta:metamodel a meta:SchemaDefinition ;
         meta:values_from,
         meta:version ;
     meta:source_file "meta.yaml" ;
-    meta:source_file_date "Tue Aug 25 16:38:08 2020"^^xsd:dateTime ;
+    meta:source_file_date "Tue Aug 25 12:56:39 2020"^^xsd:dateTime ;
     meta:source_file_size 27254 ;
     meta:subsets meta:owl ;
     meta:types meta:boolean,
@@ -258,6 +258,7 @@ meta:annotation_extension_value a meta:SlotDefinition ;
     meta:alias "value" ;
     meta:domain meta:Annotation ;
     meta:domain_of meta:Annotation ;
+    meta:imported_from "biolinkml:annotations" ;
     meta:is_a meta:extension_value ;
     meta:is_usage_slot true ;
     meta:owner meta:Annotation ;

--- a/tests/test_issues/input/issue_260/issue_260.yaml
+++ b/tests/test_issues/input/issue_260/issue_260.yaml
@@ -1,0 +1,18 @@
+id: http://example.org/tests/issue_260
+name: issue_260
+description: Test relative imports
+
+imports:
+  - issue_260a
+  - ../issue_260/issue_260b
+  - ./issue_260c
+
+classes:
+  c2601:
+    is_a: C260a
+
+  c2602:
+    is_a: C260b
+
+  c2603:
+    is_a: C260c

--- a/tests/test_issues/input/issue_260/issue_260a.yaml
+++ b/tests/test_issues/input/issue_260/issue_260a.yaml
@@ -1,0 +1,18 @@
+id: http://example.org/tests/issue_260a
+name: issue_260a
+description: Small file to be imported
+
+types:
+  string:
+    uri: xsd:string
+    base: str
+    description: A character string
+
+slots:
+  id:
+    range: string
+
+classes:
+  C260a:
+    slots:
+      - id

--- a/tests/test_issues/input/issue_260/issue_260b.yaml
+++ b/tests/test_issues/input/issue_260/issue_260b.yaml
@@ -1,0 +1,11 @@
+id: http://example.org/tests/issue_260b
+name: issue_260b
+description: Another small file to be imported
+
+imports:
+  - issue_260a
+
+classes:
+  C260b:
+    is_a: C260a
+

--- a/tests/test_issues/input/issue_260/issue_260c.yaml
+++ b/tests/test_issues/input/issue_260/issue_260c.yaml
@@ -1,0 +1,11 @@
+id: http://example.org/tests/issue_260c
+name: issue_260c
+description: Another small file to be imported
+
+imports:
+  - issue_260b
+
+classes:
+  C260c:
+    is_a: C260b
+

--- a/tests/test_issues/output/issue_260/issue_260.py
+++ b/tests/test_issues/output/issue_260/issue_260.py
@@ -1,0 +1,73 @@
+# Auto generated from issue_260.yaml by pythongen.py version: 0.4.0
+# Generation date: 2020-08-28 08:45
+# Schema: issue_260
+#
+# id: http://example.org/tests/issue_260
+# description: Test relative imports
+# license:
+
+import dataclasses
+import sys
+from typing import Optional, List, Union, Dict, ClassVar, Any
+from dataclasses import dataclass
+from biolinkml.utils.slot import Slot
+from biolinkml.utils.metamodelcore import empty_list, empty_dict, bnode
+from biolinkml.utils.yamlutils import YAMLRoot, extended_str, extended_float, extended_int
+if sys.version_info < (3, 7, 6):
+    from biolinkml.utils.dataclass_extensions_375 import dataclasses_init_fn_with_kwargs
+else:
+    from biolinkml.utils.dataclass_extensions_376 import dataclasses_init_fn_with_kwargs
+from biolinkml.utils.formatutils import camelcase, underscore, sfx
+from rdflib import Namespace, URIRef
+from biolinkml.utils.curienamespace import CurieNamespace
+from ..issue_260.issue_260b import C260b
+from .issue_260c import C260c
+from issue_260a import C260a, String
+
+metamodel_version = "1.5.3"
+
+# Overwrite dataclasses _init_fn to add **kwargs in __init__
+dataclasses._init_fn = dataclasses_init_fn_with_kwargs
+
+# Namespaces
+DEFAULT_ = CurieNamespace('', 'http://example.org/tests/issue_260/')
+
+
+# Types
+
+# Class references
+
+
+
+class C2601(C260a):
+    _inherited_slots: ClassVar[List[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = URIRef("http://example.org/tests/issue_260/C2601")
+    class_class_curie: ClassVar[str] = None
+    class_name: ClassVar[str] = "c2601"
+    class_model_uri: ClassVar[URIRef] = URIRef("http://example.org/tests/issue_260/C2601")
+
+
+class C2602(C260b):
+    _inherited_slots: ClassVar[List[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = URIRef("http://example.org/tests/issue_260/C2602")
+    class_class_curie: ClassVar[str] = None
+    class_name: ClassVar[str] = "c2602"
+    class_model_uri: ClassVar[URIRef] = URIRef("http://example.org/tests/issue_260/C2602")
+
+
+class C2603(C260c):
+    _inherited_slots: ClassVar[List[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = URIRef("http://example.org/tests/issue_260/C2603")
+    class_class_curie: ClassVar[str] = None
+    class_name: ClassVar[str] = "c2603"
+    class_model_uri: ClassVar[URIRef] = URIRef("http://example.org/tests/issue_260/C2603")
+
+
+
+# Slots
+class slots:
+    pass
+

--- a/tests/test_issues/output/issue_260/issue_260a.py
+++ b/tests/test_issues/output/issue_260/issue_260a.py
@@ -1,0 +1,65 @@
+# Auto generated from issue_260a.yaml by pythongen.py version: 0.4.0
+# Generation date: 2020-08-25 14:35
+# Schema: issue_260a
+#
+# id: http://example.org/tests/issue_260a
+# description: Small file to be imported
+# license:
+
+import dataclasses
+import sys
+from typing import Optional, List, Union, Dict, ClassVar, Any
+from dataclasses import dataclass
+from biolinkml.utils.slot import Slot
+from biolinkml.utils.metamodelcore import empty_list, empty_dict, bnode
+from biolinkml.utils.yamlutils import YAMLRoot, extended_str, extended_float, extended_int
+if sys.version_info < (3, 7, 6):
+    from biolinkml.utils.dataclass_extensions_375 import dataclasses_init_fn_with_kwargs
+else:
+    from biolinkml.utils.dataclass_extensions_376 import dataclasses_init_fn_with_kwargs
+from biolinkml.utils.formatutils import camelcase, underscore, sfx
+from rdflib import Namespace, URIRef
+from biolinkml.utils.curienamespace import CurieNamespace
+
+
+metamodel_version = "1.5.3"
+
+# Overwrite dataclasses _init_fn to add **kwargs in __init__
+dataclasses._init_fn = dataclasses_init_fn_with_kwargs
+
+# Namespaces
+XSD = CurieNamespace('xsd', 'http://example.org/UNKNOWN/xsd/')
+DEFAULT_ = CurieNamespace('', 'http://example.org/tests/issue_260a/')
+
+
+# Types
+class String(str):
+    """ A character string """
+    type_class_uri = XSD.string
+    type_class_curie = "xsd:string"
+    type_name = "string"
+    type_model_uri = URIRef("http://example.org/tests/issue_260a/String")
+
+
+# Class references
+
+
+
+@dataclass
+class C260a(YAMLRoot):
+    _inherited_slots: ClassVar[List[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = URIRef("http://example.org/tests/issue_260a/C260a")
+    class_class_curie: ClassVar[str] = None
+    class_name: ClassVar[str] = "C260a"
+    class_model_uri: ClassVar[URIRef] = URIRef("http://example.org/tests/issue_260a/C260a")
+
+    id: Optional[str] = None
+
+
+# Slots
+class slots:
+    pass
+
+slots.id = Slot(uri=DEFAULT_.id, name="id", curie=DEFAULT_.curie('id'),
+                      model_uri=DEFAULT_.id, domain=None, range=Optional[str])

--- a/tests/test_issues/output/issue_260/issue_260b.py
+++ b/tests/test_issues/output/issue_260/issue_260b.py
@@ -1,0 +1,53 @@
+# Auto generated from issue_260b.yaml by pythongen.py version: 0.4.0
+# Generation date: 2020-08-28 08:45
+# Schema: issue_260b
+#
+# id: http://example.org/tests/issue_260b
+# description: Another small file to be imported
+# license:
+
+import dataclasses
+import sys
+from typing import Optional, List, Union, Dict, ClassVar, Any
+from dataclasses import dataclass
+from biolinkml.utils.slot import Slot
+from biolinkml.utils.metamodelcore import empty_list, empty_dict, bnode
+from biolinkml.utils.yamlutils import YAMLRoot, extended_str, extended_float, extended_int
+if sys.version_info < (3, 7, 6):
+    from biolinkml.utils.dataclass_extensions_375 import dataclasses_init_fn_with_kwargs
+else:
+    from biolinkml.utils.dataclass_extensions_376 import dataclasses_init_fn_with_kwargs
+from biolinkml.utils.formatutils import camelcase, underscore, sfx
+from rdflib import Namespace, URIRef
+from biolinkml.utils.curienamespace import CurieNamespace
+from issue_260a import C260a, String
+
+metamodel_version = "1.5.3"
+
+# Overwrite dataclasses _init_fn to add **kwargs in __init__
+dataclasses._init_fn = dataclasses_init_fn_with_kwargs
+
+# Namespaces
+DEFAULT_ = CurieNamespace('', 'http://example.org/tests/issue_260b/')
+
+
+# Types
+
+# Class references
+
+
+
+class C260b(C260a):
+    _inherited_slots: ClassVar[List[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = URIRef("http://example.org/tests/issue_260b/C260b")
+    class_class_curie: ClassVar[str] = None
+    class_name: ClassVar[str] = "C260b"
+    class_model_uri: ClassVar[URIRef] = URIRef("http://example.org/tests/issue_260b/C260b")
+
+
+
+# Slots
+class slots:
+    pass
+

--- a/tests/test_issues/output/issue_260/issue_260c.py
+++ b/tests/test_issues/output/issue_260/issue_260c.py
@@ -1,0 +1,54 @@
+# Auto generated from issue_260c.yaml by pythongen.py version: 0.4.0
+# Generation date: 2020-08-28 08:45
+# Schema: issue_260c
+#
+# id: http://example.org/tests/issue_260c
+# description: Another small file to be imported
+# license:
+
+import dataclasses
+import sys
+from typing import Optional, List, Union, Dict, ClassVar, Any
+from dataclasses import dataclass
+from biolinkml.utils.slot import Slot
+from biolinkml.utils.metamodelcore import empty_list, empty_dict, bnode
+from biolinkml.utils.yamlutils import YAMLRoot, extended_str, extended_float, extended_int
+if sys.version_info < (3, 7, 6):
+    from biolinkml.utils.dataclass_extensions_375 import dataclasses_init_fn_with_kwargs
+else:
+    from biolinkml.utils.dataclass_extensions_376 import dataclasses_init_fn_with_kwargs
+from biolinkml.utils.formatutils import camelcase, underscore, sfx
+from rdflib import Namespace, URIRef
+from biolinkml.utils.curienamespace import CurieNamespace
+from issue_260a import String
+from issue_260b import C260b
+
+metamodel_version = "1.5.3"
+
+# Overwrite dataclasses _init_fn to add **kwargs in __init__
+dataclasses._init_fn = dataclasses_init_fn_with_kwargs
+
+# Namespaces
+DEFAULT_ = CurieNamespace('', 'http://example.org/tests/issue_260c/')
+
+
+# Types
+
+# Class references
+
+
+
+class C260c(C260b):
+    _inherited_slots: ClassVar[List[str]] = []
+
+    class_class_uri: ClassVar[URIRef] = URIRef("http://example.org/tests/issue_260c/C260c")
+    class_class_curie: ClassVar[str] = None
+    class_name: ClassVar[str] = "C260c"
+    class_model_uri: ClassVar[URIRef] = URIRef("http://example.org/tests/issue_260c/C260c")
+
+
+
+# Slots
+class slots:
+    pass
+

--- a/tests/test_issues/test_issue_260.py
+++ b/tests/test_issues/test_issue_260.py
@@ -1,0 +1,42 @@
+import os
+import unittest
+
+from biolinkml.generators.pythongen import PythonGenerator
+from tests.test_issues.environment import env
+from tests.utils.python_comparator import compare_python
+from tests.utils.test_environment import TestEnvironmentTestCase
+
+
+class Issue260TestCase(TestEnvironmentTestCase):
+    env = env
+
+    def test_local_imports(self):
+        """ Check the local import behavior """
+        dir = 'issue_260'
+
+        # Useful to have an __init__.py available
+        init_path = env.actual_path(dir, '__init__.py')
+        if not os.path.exists(init_path):
+            with open(init_path, 'w'):
+                pass
+
+        env.generate_single_file('issue_260/issue_260a.py',
+                                 lambda: PythonGenerator(env.input_path(dir, 'issue_260a.yaml'),
+                                                         importmap=env.import_map, mergeimports=False).serialize(),
+                                 comparator=compare_python, value_is_returned=True)
+        env.generate_single_file('issue_260/issue_260b.py',
+                                 lambda: PythonGenerator(env.input_path(dir, 'issue_260b.yaml'),
+                                                         importmap=env.import_map, mergeimports=False).serialize(),
+                                 comparator=compare_python, value_is_returned=True)
+        env.generate_single_file('issue_260/issue_260c.py',
+                                 lambda: PythonGenerator(env.input_path(dir, 'issue_260c.yaml'),
+                                                         importmap=env.import_map, mergeimports=False).serialize(),
+                                 comparator=compare_python, value_is_returned=True)
+        env.generate_single_file('issue_260/issue_260.py',
+                                 lambda: PythonGenerator(env.input_path(dir, 'issue_260.yaml'),
+                                                         importmap=env.import_map, mergeimports=False).serialize(),
+                                 comparator=compare_python, value_is_returned=True)
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
That said, relative imports seem to fail in a lot of situations.  We need to fix this to import relative to the base of a project.
Fixed a TCCM bug where not all identifiers were being imported.
Some work to get a line # associated with a missing import, but still not complete.
Fixed an issue where all imported slots were getting added to the slot list, which is why meta.py was updated