### PR TITLE
SPARQL queries for models and instance data #229

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,6 +32,8 @@ examples/%.proto: examples/%.yaml
 	$(RUN) gen-proto $< > $@
 examples/%.owl: examples/%.yaml
 	$(RUN) gen-owl $< > $@
+examples/%.ttl: examples/%.yaml
+	$(RUN) gen-rdf $< > $@
 examples/%-docs: examples/%.yaml
 	$(RUN) gen-markdown $< -d $@
 

--- a/sparql/README.md
+++ b/sparql/README.md
@@ -1,0 +1,39 @@
+# BiolinkML SPARQL checks
+
+These sparql checks can be used to query either biolinkML schemas or
+instance data for biolinkML schemas.
+
+The schema should be in the form of a .ttl file (using gen-rdf).
+
+For instance data, this should be merged with the schema.ttl
+
+The script [meta-sparql.sh](meta-sparql.sh) provides a convenient
+wrapper that use robot to merge files and do queries.
+
+## Naming conventions
+
+ - queries over schemas are named `schema-*.rq`
+ - queries intended to check for warnings/errors are named `*-check.rq`
+
+## Examples (schemas)
+
+To query for all elements in a schema:
+
+`./sparql/meta-sparql.sh  -s examples/organization2.ttl -q sparql/element-list.rq`
+
+The metamodel can be queried:
+
+`./sparql/meta-sparql.sh  -s meta.ttl -q sparql/element-list.rq`
+
+## Examples (instance data)
+
+Find all unyped instances
+
+`./sparql/meta-sparql.sh -i examples/organization2.ttl -s examples/organization2.ttl -q sparql/untyped-instance-violation.rq`
+
+# TODO
+
+ - move validation into python code
+ - add tests
+ - add more constraint checking
+

--- a/sparql/domain-check.rq
+++ b/sparql/domain-check.rq
@@ -1,0 +1,5 @@
+SELECT
+WHERE
+ ?cls meta:domain ?domain .
+ ?i (rdf:type)/(meta:is_a)* ?cls .
+ 

--- a/sparql/meta-sparql.sh
+++ b/sparql/meta-sparql.sh
@@ -1,0 +1,21 @@
+#!/bin/sh
+while getopts hi:s:q: flag
+do
+    case "${flag}" in
+        h)
+            echo "TODO"
+            exit 0
+            ;;
+        i) input=${OPTARG};;
+        s) schema=${OPTARG};;
+        q) query=${OPTARG};;
+    esac
+done
+OUT="$(mktemp)"
+SCRIPT="$0"
+SDIR="$(dirname $SCRIPT)"
+DIR="$SDIR/.."
+ARG_I=$([ $input ] && echo "-i $input" || echo  )
+robot merge -i $DIR/meta.ttl -i $schema $ARG_I query -P $DIR/context.jsonld -f tsv  --query $query $OUT
+cat $OUT
+rm $OUT

--- a/sparql/required-slot-check.rq
+++ b/sparql/required-slot-check.rq
@@ -1,0 +1,19 @@
+prefix : <https://w3id.org/biolink/biolinkml/meta/> 
+prefix skos: <http://www.w3.org/2004/02/skos/core#>
+prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+SELECT DISTINCT ?i ?requiredProperty ?type ?slotDef
+WHERE {
+  {
+   { ?i rdf:type ?type }
+   UNION 
+   { ?typeProperty (:is_a|:mixin)*/:slot_uri rdf:type .
+     ?i ?typeProperty ?type }
+  }
+  ?type (:is_a|:mixin)*/:slots ?slotDef .
+  FILTER( ?slotDef != :name )   ## TODO - check why this is not injected into the schema
+  ?slotDef :slot_uri ?requiredProperty .
+  ?slotDef :required true .
+  FILTER( NOT EXISTS {?i ?requiredProperty ?v} )
+  FILTER( NOT EXISTS {?slotDef :identifier true} )  ## identifier is used as the IRI of ?i, no separate property
+}

--- a/sparql/schema-element-list.rq
+++ b/sparql/schema-element-list.rq
@@ -1,0 +1,12 @@
+#+ description: report all elements and their types
+
+prefix : <https://w3id.org/biolink/biolinkml/meta/> 
+prefix skos: <http://www.w3.org/2004/02/skos/core#>
+
+SELECT ?scheme  ?ElementClass ?element ?def
+WHERE {
+  ?ElementClass :is_a* :Element .
+  ?element a ?ElementClass .
+  ?element skos:inScheme ?scheme
+  OPTIONAL { ?element skos:definition ?def } 
+}

--- a/sparql/schema-mapping-list.rq
+++ b/sparql/schema-mapping-list.rq
@@ -1,0 +1,11 @@
+#+ description: report all mappings and their types
+
+prefix : <https://w3id.org/biolink/biolinkml/meta/> 
+prefix skos: <http://www.w3.org/2004/02/skos/core#>
+
+SELECT DISTINCT ?scheme ?element ?predicate ?mapped_to
+WHERE {
+  ?element ?predicate ?mapped_to .
+  VALUES ?predicate {skos:exactMatch skos:narrowMatch skos:broadMatch skos:relatedMatch skos:closeMatch skos:mappingRelation} .
+  ?element skos:inScheme ?scheme
+}

--- a/sparql/schema-slot-inferred-class-range.rq
+++ b/sparql/schema-slot-inferred-class-range.rq
@@ -1,0 +1,11 @@
+prefix : <https://w3id.org/biolink/biolinkml/meta/> 
+prefix skos: <http://www.w3.org/2004/02/skos/core#>
+
+SELECT DISTINCT ?scheme  ?p ?range
+WHERE {
+  ?p a :SlotDefinition .
+  ?p (:is_a|:mixin)* ?pAnc .
+  ?p :range ?rangeDirect .
+  ?rangeDirect (:is_a|:mixin)* ?range .
+  ?p skos:inScheme ?scheme
+}

--- a/sparql/undefined-slot-check.rq
+++ b/sparql/undefined-slot-check.rq
@@ -1,0 +1,24 @@
+#TODO
+#+ description: report all unknown slots
+
+prefix : <https://w3id.org/biolink/biolinkml/meta/> 
+prefix skos: <http://www.w3.org/2004/02/skos/core#>
+prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+SELECT DISTINCT ?s ?p ?o ?cls ?scheme
+WHERE {
+  ?s ?p ?o .
+  {
+    {?s rdf:type ?cls }
+    UNION
+    {?s ?typePred ?cls .
+     ?typePred (:is_a|:mixin)* ?typePredInf .
+     ?typePredInf :slot_uri rdf:type
+    }
+  }
+  ?cls a :ClassDefinition .
+  ?cls skos:inScheme ?scheme
+  
+  FILTER( NOT EXISTS { ?p a :SlotDefinition} ) 
+  FILTER( !isBlank(?s) )
+}

--- a/sparql/untyped-instance-check.rq
+++ b/sparql/untyped-instance-check.rq
@@ -1,0 +1,17 @@
+#+ description: report all elements and their types
+
+prefix : <https://w3id.org/biolink/biolinkml/meta/> 
+prefix skos: <http://www.w3.org/2004/02/skos/core#>
+prefix rdf: <http://www.w3.org/1999/02/22-rdf-syntax-ns#>
+
+SELECT DISTINCT ?i
+WHERE {
+  ?i ?p ?o .
+  FILTER( NOT EXISTS { ?i rdf:type ?t} ) .
+  FILTER( NOT EXISTS {
+     ?i ?typePref ?t .
+     ?typePred :is_a* ?typePredInf .
+     ?typePrefInf :slot_uri rdf:type 
+     } ) .
+  FILTER( !isBlank(?i) )
+}


### PR DESCRIPTION
See https://github.com/linkml/linkml/issues/46

# BiolinkML SPARQL checks

These sparql checks can be used to query either biolinkML schemas or
instance data for biolinkML schemas.

The schema should be in the form of a .ttl file (using gen-rdf).

For instance data, this should be merged with the schema.ttl

The script [meta-sparql.sh](meta-sparql.sh) provides a convenient
wrapper that use robot to merge files and do queries.

## Naming conventions

 - queries over schemas are named `schema-*.rq`
 - queries intended to check for warnings/errors are named `*-check.rq`

## Examples (schemas)

To query for all elements in a schema:

`./sparql/meta-sparql.sh  -s examples/organization2.ttl -q sparql/element-list.rq`

The metamodel can be queried:

`./sparql/meta-sparql.sh  -s meta.ttl -q sparql/element-list.rq`

## Examples (instance data)

Find all unyped instances

`./sparql/meta-sparql.sh -i examples/organization2.ttl -s examples/organization2.ttl -q sparql/untyped-instance-violation.rq`

# TODO

 - move validation into python code
 - add tests
 - add more constraint checking

