### PR TITLE
Issue 344

### DIFF
--- a/biolinkml/generators/jsonldcontextgen.py
+++ b/biolinkml/generators/jsonldcontextgen.py
@@ -147,7 +147,9 @@ license: {be(self.schema.license)}
         :param defn: Class or Slot Definition
         """
         self.add_id_prefixes(defn)
-        for mapping in defn.mappings:
+        mappings = defn.mappings + defn.related_mappings + defn.close_mappings + \
+                   defn.narrow_mappings + defn.broad_mappings + defn.exact_mappings
+        for mapping in mappings:
             if '://' in mapping:
                 mcurie = self.namespaces.curie_for(mapping)
                 if mcurie is None:

--- a/tests/test_issues/input/issue_344.yaml
+++ b/tests/test_issues/input/issue_344.yaml
@@ -1,0 +1,21 @@
+id: http://example.org/tests/issue344
+name: annotations_test
+
+prefixes:
+  ex: http://example.org/
+  biolinkml: https://w3id.org/biolink/biolinkml/
+
+default_prefix: ex
+
+default_curi_maps:
+    - obo_context
+
+classes:
+  my class:
+    description: >-
+      A simple class
+    exact_mappings:
+      - PCO:12345
+      - PATO:12345
+    narrow_mappings:
+      - GO:12345

--- a/tests/test_issues/test_issue_344.py
+++ b/tests/test_issues/test_issue_344.py
@@ -2,12 +2,7 @@ import json
 import os
 import unittest
 
-from biolinkml.utils.schemaloader import SchemaLoader
-
-from biolinkml.utils.yamlutils import as_yaml
-
 from biolinkml.generators.jsonldcontextgen import ContextGenerator
-from tests.utils.filters import yaml_filter
 from tests.utils.test_environment import TestEnvironmentTestCase
 from tests.test_issues.environment import env
 

--- a/tests/test_issues/test_issue_344.py
+++ b/tests/test_issues/test_issue_344.py
@@ -1,0 +1,30 @@
+import json
+import os
+import unittest
+
+from biolinkml.utils.schemaloader import SchemaLoader
+
+from biolinkml.utils.yamlutils import as_yaml
+
+from biolinkml.generators.jsonldcontextgen import ContextGenerator
+from tests.utils.filters import yaml_filter
+from tests.utils.test_environment import TestEnvironmentTestCase
+from tests.test_issues.environment import env
+
+
+class Issue167TestCase(TestEnvironmentTestCase):
+    env = env
+
+    def test_issue_344(self):
+        """ Test to check if prefixes of CURIEs from granular mappings show up in the json-ld context """
+        x = env.generate_single_file('issue_344_context.json',
+                                 lambda: ContextGenerator(env.input_path('issue_344.yaml'),
+                                 importmap=env.import_map).serialize(), value_is_returned=True)
+        context = json.load(open(os.path.join(env.outdir, 'issue_344_context.json')))
+        self.assertIn('PCO', context['@context'])
+        self.assertIn('PATO', context['@context'])
+        self.assertIn('GO', context['@context'])
+
+
+if __name__ == '__main__':
+    unittest.main()


### PR DESCRIPTION
Fixes concerns raised in #344 where jsonldcontexgen.py was not emitting prefixes in CURIEs represented in (related|close|narrow|broad|exact)_mappings.
