### PR TITLE
add antonymy as a meta model attribute

### DIFF
--- a/meta.yaml
+++ b/meta.yaml
@@ -709,6 +709,12 @@ slots:
     description: indicates that any instance of d s r implies that there is also an instance of r s' d
     slot_uri: owl:inverseOf
 
+  antonymy:
+    domain: slot_definition
+    range: slot_definition
+    description: >-
+      the state or phenomenon in which the words have the sense relation which involve the opposite of meaning.
+
   is_class_field:
     domain: slot_definition
     range: boolean

--- a/meta.yaml
+++ b/meta.yaml
@@ -709,7 +709,7 @@ slots:
     description: indicates that any instance of d s r implies that there is also an instance of r s' d
     slot_uri: owl:inverseOf
 
-  antonymy:
+  antonym_of:
     domain: slot_definition
     range: slot_definition
     description: >-


### PR DESCRIPTION
to allow tagging of 'opposites in biolink-model.  chose antonymy instead of opposite we might want to allow opposition on a gradient.  Perhaps there is a more precise way to do this. 
fixes #395 